### PR TITLE
Remove removed unstable features

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -102,8 +102,8 @@ pub mod hs {
                     // 1024 bytes is enough for RSA-8192 keys.
                     let mut signature = [0u8; 1024];
                     let signature = &mut signature[..key.public_modulus_len()];
-                    key.sign(&ring::signature::RSA_PKCS1_SHA512, random, data, signature)
-                        .expect("Failed to compute RSA_PKCS1_SHA512 signature");
+                    key.sign(&ring::signature::RSA_PKCS1_SHA256, random, data, signature)
+                        .expect("Failed to compute RSA_PKCS1_SHA256 signature");
                     output.write_all(signature)
                 }
                 Inner::RsaPss { key, random, .. } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![forbid(unsafe_code)]
-#![feature(generic_associated_types)]
-#![feature(min_type_alias_impl_trait)]
 
 mod algorithm;
 pub mod request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -184,10 +184,10 @@ impl Method {
 pub trait Headers {
     /// Iterator over header names. This library can only work with header names that are
     /// valid UTF-8 (and by extension, all ASCII-only headers).
-    type NameIter<'a> : Iterator<Item = &'a str>;
+    type NameIter<'a> : Iterator<Item = &'a str> where Self: 'a;
     /// Iterator over header values. Header values are allowed to be arbitrary byte
     /// strings in any encoding.
-    type ValueIter<'a> : Iterator<Item = &'a [u8]>;
+    type ValueIter<'a> : Iterator<Item = &'a [u8]> where Self: 'a;
 
     /// Returns an iterator over all the header names defined for the HTTP request.
     fn header_names<'this>(&'this self) -> Self::NameIter<'this>;


### PR DESCRIPTION
Hello there! I recently tried to add this project to mine as a dependency and got a compilation failure while it was trying to build this library. The reason for the errors is a set of unstable features which are no longer needed and/or removed:

- `generic_associated_typed`: generic associated types were recently stabilized
- `min_type_alias_impl_trait`: deprecated in favor of `type_alias_impl_trait`